### PR TITLE
Adding appendTo and css properties

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "jquery-auto-complete",
-	"description": "A lightweight autocomplete plugin for jQuery.",
+    "description": "A lightweight autocomplete plugin for jQuery.",
     "version": "1.0.7",
     "dependencies": {
         "jquery": ">=1.7"
@@ -31,5 +31,8 @@
         "demo.html",
         "auto-complete.jquery.json",
         "readme.md"
+    ],
+    "main": [
+        "jquery-auto-complete.js"
     ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "jquery-auto-complete",
     "description": "A lightweight autocomplete plugin for jQuery.",
-    "version": "1.0.8",
+    "version": "2.0.0",
     "dependencies": {
         "jquery": ">=1.7"
     },

--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,19 @@
 {
     "name": "jquery-auto-complete",
     "description": "A lightweight autocomplete plugin for jQuery.",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "dependencies": {
         "jquery": ">=1.7"
     },
-    "homepage": "https://github.com/Pixabay/jQuery-autoComplete",
+    "homepage": "https://github.com/fahimfarookme/jQuery-autoComplete.git",
     "authors": [{
         "name": "Simon Steinberger",
         "url": "https://pixabay.com/users/Simon/",
         "email": "simon@pixabay.com"
+    }, {
+        "name": "Fahim Farook",
+        "url": "https://github.com/fahimfarookme/",
+        "email": "fahim@fahimfarook.me"
     }],
     "keywords": [
         "autocomplete",
@@ -27,7 +31,6 @@
         "url": "http://www.opensource.org/licenses/mit-license.php"
     }],
     "ignore": [
-        "bower.json",
         "demo.html",
         "auto-complete.jquery.json",
         "readme.md"

--- a/jquery.auto-complete.js
+++ b/jquery.auto-complete.js
@@ -55,7 +55,7 @@
             }
             $(window).on('resize.autocomplete', that.updateSC);
 
-            that.sc.appendTo(o.appendTo);
+            that.sc.appendTo(o.appendTo || 'body');
 
             that.sc.on('mouseleave', '.autocomplete-suggestion', function (){
                 $('.autocomplete-suggestion.selected').removeClass('selected');

--- a/jquery.auto-complete.js
+++ b/jquery.auto-complete.js
@@ -37,11 +37,7 @@
             that.last_val = '';
 
             that.updateSC = function(resize, next){
-                that.sc.css({
-                    top: that.offset().top + that.outerHeight(),
-                    left: that.offset().left,
-                    width: that.outerWidth()
-                });
+                o.css && that.sc.css(o.css);
                 if (!resize) {
                     that.sc.show();
                     if (!that.sc.maxHeight) that.sc.maxHeight = parseInt(that.sc.css('max-height'));
@@ -59,7 +55,7 @@
             }
             $(window).on('resize.autocomplete', that.updateSC);
 
-            that.sc.appendTo('body');
+            that.sc.appendTo(o.appendTo);
 
             that.sc.on('mouseleave', '.autocomplete-suggestion', function (){
                 $('.autocomplete-suggestion.selected').removeClass('selected');


### PR DESCRIPTION
Rather than appending the container to body, provide a appendTo property.
Provide a css property where clients can add any css property which is intended to be inline. (Since setting inline width property doesn't work always for complex layouts)
