### PR TITLE
Added apendTo and css properties

### DIFF
--- a/jquery.auto-complete.js
+++ b/jquery.auto-complete.js
@@ -37,11 +37,7 @@
             that.last_val = '';
 
             that.updateSC = function(resize, next){
-                that.sc.css({
-                    top: that.offset().top + that.outerHeight(),
-                    left: that.offset().left,
-                    width: that.outerWidth()
-                });
+                o.css && that.sc.css(o.css);
                 if (!resize) {
                     that.sc.show();
                     if (!that.sc.maxHeight) that.sc.maxHeight = parseInt(that.sc.css('max-height'));
@@ -59,7 +55,7 @@
             }
             $(window).on('resize.autocomplete', that.updateSC);
 
-            that.sc.appendTo('body');
+            that.sc.appendTo(o.appendTo || 'body');
 
             that.sc.on('mouseleave', '.autocomplete-suggestion', function (){
                 $('.autocomplete-suggestion.selected').removeClass('selected');


### PR DESCRIPTION
Rather than appending the container to body, provide a appendTo property.
Provide a css property where clients can add any css property which is intended to be inline. (Since setting inline width property doesn't work always for complex layouts)
