### PR TITLE
Create an event to manually trigger the search

### DIFF
--- a/jquery.auto-complete.js
+++ b/jquery.auto-complete.js
@@ -103,7 +103,12 @@
                 else
                     that.sc.hide();
             }
-
+	    // manually trigger the autocomplete popup
+            that.on('autocomplete.popup', function(e) { 
+		    var val = that.val();
+		    o.source(val,suggest);
+	    });
+		
             that.on('keydown.autocomplete', function(e){
                 // down (40), up (38)
                 if ((e.which == 40 || e.which == 38) && that.sc.html()) {
@@ -143,7 +148,7 @@
                                     if (part in that.cache && !that.cache[part].length) { suggest([]); return; }
                                 }
                             }
-                            that.timer = setTimeout(function(){ o.source(val, suggest) }, o.delay);
+                            that.timer = setTimeout(function(){ that.trigger('autocomplete.popup') }, o.delay);
                         }
                     } else {
                         that.last_val = val;


### PR DESCRIPTION
It may be useful to ask this plugin to show it's suggestions immediately, perhaps from a virtual keyboard that doesn't send real keydown events or some other trigger.  This change creates a new 'autocomplete.popup' event that can be triggered through jQuery's trigger() routine to request it immediately do the search and reveal the results.