### PR TITLE
Make it possible to set the value of 'autocomplete' to something else.

### DIFF
--- a/jquery.auto-complete.js
+++ b/jquery.auto-complete.js
@@ -32,7 +32,7 @@
             // sc = 'suggestions container'
             that.sc = $('<div class="autocomplete-suggestions '+o.menuClass+'"></div>');
             that.data('sc', that.sc).data('autocomplete', that.attr('autocomplete'));
-            that.attr('autocomplete', 'off');
+            that.attr('autocomplete', that.data('autocomplete-override') || 'off');
             that.cache = {};
             that.last_val = '';
 


### PR DESCRIPTION
Recent browser updates doesn't acknowledge autocomplete='off', so this minor change make it possible to have that attribute set to an alternative value.

I just chose the name 'autocomplete-override'. Feel free to go for another solution.